### PR TITLE
meta: add 'new items to project board' workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,14 @@
+name: Add new item to project board
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+      uses: unleash/.github/.github/workflows/add-item-to-project.yml@main
+      secrets: inherit


### PR DESCRIPTION
This change adds a workflow to automatically add new issues and PRs to
a specified project board for easier watching